### PR TITLE
Refine non-stackable purchases and add mailbox shortcut

### DIFF
--- a/src/main/java/pl/dsocraft/auctionhouse/managers/GUIManager.java
+++ b/src/main/java/pl/dsocraft/auctionhouse/managers/GUIManager.java
@@ -37,6 +37,7 @@ public class GUIManager {
     // GUI constants
     private static final int INVENTORY_SIZE = 54; // 6 rows
     private static final int ITEMS_PER_PAGE = 45; // 5 rows of items
+    private static final int MAILBOX_BUTTON_SLOT = 46;
     private static final int PREV_PAGE_SLOT = 45;
     private static final int NEXT_PAGE_SLOT = 53;
     private static final int BACK_BUTTON_SLOT = 49;
@@ -106,21 +107,25 @@ public class GUIManager {
         // Add navigation buttons
         if (paginator.hasPreviousPage()) {
             inventory.setItem(PREV_PAGE_SLOT, createNavigationButton(
-                    Material.ARROW, "Previous Page"));
+                    Material.ARROW, plugin.getConfig().getString("gui.buttons.previous_page", "&cPrevious Page")));
         } else {
             inventory.setItem(PREV_PAGE_SLOT, fillerItem);
         }
 
         if (paginator.hasNextPage()) {
             inventory.setItem(NEXT_PAGE_SLOT, createNavigationButton(
-                    Material.ARROW, "Next Page"));
+                    Material.ARROW, plugin.getConfig().getString("gui.buttons.next_page", "&aNext Page")));
         } else {
             inventory.setItem(NEXT_PAGE_SLOT, fillerItem);
         }
 
+        // Add mailbox shortcut
+        inventory.setItem(MAILBOX_BUTTON_SLOT, createNavigationButton(
+                Material.CHEST, plugin.getConfig().getString("gui.buttons.mailbox", "&eMailbox")));
+
         // Fill remaining slots with filler item
         for (int i = ITEMS_PER_PAGE; i < INVENTORY_SIZE; i++) {
-            if (i != PREV_PAGE_SLOT && i != NEXT_PAGE_SLOT) {
+            if (i != PREV_PAGE_SLOT && i != NEXT_PAGE_SLOT && i != MAILBOX_BUTTON_SLOT) {
                 inventory.setItem(i, fillerItem);
             }
         }
@@ -283,22 +288,34 @@ public class GUIManager {
         // Item being purchased in the center
         inventory.setItem(13, createAuctionItemStack(auctionItem, player));
 
-        // Confirmation buttons
-        String buyAllText = plugin.getConfig().getString("gui.buttons.confirm_purchase_lmb", "&aBuy All (LMB)");
-        String buyOneText = plugin.getConfig().getString("gui.buttons.confirm_purchase_rmb", "&aBuy One (RMB)");
-        String buyAmountText = plugin.getConfig().getString("gui.buttons.confirm_purchase_mmb", "&aBuy Amount (MMB)");
+        // Confirmation button setup depends on stackability
+        boolean isStackable = auctionItem.getItemStack().getMaxStackSize() > 1;
 
         ItemStack confirmButton = new ItemStack(Material.EMERALD_BLOCK);
         ItemMeta confirmMeta = confirmButton.getItemMeta();
-        confirmMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', buyAllText));
         List<String> confirmLore = new ArrayList<>();
-        confirmLore.add(ChatColor.translateAlternateColorCodes('&', buyOneText));
-        confirmLore.add(ChatColor.translateAlternateColorCodes('&', buyAmountText));
-        confirmLore.add("");
-        confirmLore.add(ChatColor.YELLOW + "Total Price: " + 
-                ChatColor.GREEN + plugin.getMessageManager().formatPrice(auctionItem.getPriceForRemaining()));
-        confirmLore.add(ChatColor.YELLOW + "Price Per Item: " + 
-                ChatColor.GREEN + plugin.getMessageManager().formatPrice(auctionItem.getPricePerItem()));
+
+        if (isStackable) {
+            String buyAllText = plugin.getConfig().getString("gui.buttons.confirm_purchase_lmb", "&aBuy All (LMB)");
+            String buyOneText = plugin.getConfig().getString("gui.buttons.confirm_purchase_rmb", "&aBuy One (RMB)");
+            String buyAmountText = plugin.getConfig().getString("gui.buttons.confirm_purchase_mmb", "&aBuy Amount (MMB)");
+
+            confirmMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', buyAllText));
+            confirmLore.add(ChatColor.translateAlternateColorCodes('&', buyOneText));
+            confirmLore.add(ChatColor.translateAlternateColorCodes('&', buyAmountText));
+            confirmLore.add("");
+            confirmLore.add(ChatColor.YELLOW + "Total Price: " +
+                    ChatColor.GREEN + plugin.getMessageManager().formatPrice(auctionItem.getPriceForRemaining()));
+            confirmLore.add(ChatColor.YELLOW + "Price Per Item: " +
+                    ChatColor.GREEN + plugin.getMessageManager().formatPrice(auctionItem.getPricePerItem()));
+        } else {
+            String buyItemText = plugin.getConfig().getString("gui.buttons.confirm_purchase_single", "&aBuy Item");
+            confirmMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', buyItemText));
+            confirmLore.add("");
+            confirmLore.add(ChatColor.YELLOW + "Price: " +
+                    ChatColor.GREEN + plugin.getMessageManager().formatPrice(auctionItem.getPriceForRemaining()));
+        }
+
         confirmMeta.setLore(confirmLore);
         confirmButton.setItemMeta(confirmMeta);
         inventory.setItem(11, confirmButton);
@@ -556,6 +573,9 @@ public class GUIManager {
             return handleNextPageClick(player, currentInventoryTitle);
         } else if (slot == BACK_BUTTON_SLOT) {
             return handleBackButtonClick(player, currentInventoryTitle);
+        } else if (slot == MAILBOX_BUTTON_SLOT && currentInventoryTitle.contains("Auction House")) {
+            openMailboxGUI(player);
+            return true;
         }
 
         return false;
@@ -650,7 +670,14 @@ public class GUIManager {
         }
 
         if (slot == 11) { // Confirm button
-            if (isMiddleClick) {
+            boolean isStackable = auctionItem.getItemStack().getMaxStackSize() > 1;
+
+            if (!isStackable) {
+                // Non-stackable item: always buy the whole item
+                player.closeInventory();
+                plugin.getAuctionManager().purchaseItem(player, auctionId, auctionItem.getQuantityRemaining());
+                pendingPurchases.remove(player.getUniqueId());
+            } else if (isMiddleClick) {
                 // Middle click - buy specific amount
                 player.closeInventory();
                 awaitingChatInput.add(player.getUniqueId());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,9 +20,11 @@ gui:
     previous_page: "&cPrevious Page"
     next_page: "&aNext Page"
     back: "&eBack"
+    mailbox: "&eMailbox"
     confirm_purchase_lmb: "&aBuy All (LMB)"
     confirm_purchase_rmb: "&aBuy One (RMB)"
     confirm_purchase_mmb: "&aBuy Amount (MMB)"
+    confirm_purchase_single: "&aBuy Item"
 
 # Auction limits by rank
 limits:


### PR DESCRIPTION
## Summary
- restrict purchase options for non-stackable items to full-stack only
- add configurable mailbox shortcut without displacing page navigation
- expose mailbox and single-buy labels in config

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688bafef319c832a87496fb61338d003