### PR TITLE
Refine non-stackable purchases and center mailbox shortcut

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,9 +20,11 @@ gui:
     previous_page: "&cPrevious Page"
     next_page: "&aNext Page"
     back: "&eBack"
+    mailbox: "&eMailbox"
     confirm_purchase_lmb: "&aBuy All (LMB)"
     confirm_purchase_rmb: "&aBuy One (RMB)"
     confirm_purchase_mmb: "&aBuy Amount (MMB)"
+    confirm_purchase_single: "&aBuy Item"
 
 # Auction limits by rank
 limits:


### PR DESCRIPTION
## Summary
- restrict purchase options for non-stackable items to full-stack only
- add configurable mailbox shortcut centered without affecting page navigation
- expose mailbox and single-buy labels in config
- sanitize mailbox source info to avoid MySQL encoding errors
- remove sold-out listings immediately and filter them from player shops
- harden mailbox GUI against missing item data and move shortcut to bottom-left slot

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688bafef319c832a87496fb61338d003